### PR TITLE
Handling error in importing json_normalize

### DIFF
--- a/dimcli/core/utils.py
+++ b/dimcli/core/utils.py
@@ -9,8 +9,11 @@ import subprocess
 import os
 import webbrowser
 from itertools import islice
-from pandas import json_normalize, DataFrame
-
+from pandas import DataFrame
+try:
+    from pandas import json_normalize
+except:
+    from pandas.io.json import json_normalize
 from .dsl_grammar import *
 from .html import html_template_interactive
 


### PR DESCRIPTION
In VS Code on Windows, using pandas 0.25.1, I get an error in importing the dimcli library, related to the import of json_normalize
I've added handling of error in importing json_normalize - same as in use in in core/dataframe_factory.py

