### PR TITLE
Fixing pandas warning about using keyword args

### DIFF
--- a/dimcli/core/dataframe_factory.py
+++ b/dimcli/core/dataframe_factory.py
@@ -172,7 +172,7 @@ class DfFactory(object):
             df.dropna(subset=[FIELD_NAME_SCORES], inplace=True)  # remove rows if there is no concept
             df.reset_index(inplace=True, drop=True)
             original_cols = [x for x in df.columns.to_list() if x != FIELD_NAME_SCORES]
-            df = df.drop(FIELD_NAME_SCORES, 1).assign(**pd.json_normalize(df[FIELD_NAME_SCORES]))  # unpack dict with new columns
+            df = df.drop(FIELD_NAME_SCORES, axis=1).assign(**pd.json_normalize(df[FIELD_NAME_SCORES]))  # unpack dict with new columns
             df = df[df.relevance != 0]  # remove 0-relevance scores
             df['relevance'] = df['relevance'].round(ROUNDING)
             df.rename(columns={"relevance": "score"}, inplace=True) 


### PR DESCRIPTION
Calls to the `df_concepts` method can throw this warning:

/site-packages/dimcli/core/dataframe_factory.py:175: FutureWarning: In a future version of pandas all arguments of DataFrame.drop except for the argument 'labels' will be keyword-only
  df = df.drop(FIELD_NAME_SCORES, 1).assign(**pd.json_normalize(df[FIELD_NAME_SCORES]))  # unpack dict with new columns


This changes the call to `dataframe.drop` to use keywords rather than argument order.