### PR TITLE
Solves a TODO in `remove_fulltext_search_clause`

### DIFF
--- a/dimcli/utils/repl_utils.py
+++ b/dimcli/utils/repl_utils.py
@@ -121,13 +121,13 @@ def remove_fulltext_search_clause(line):
         re.sub(r'\"(.+?)\"', "", a)
         # => 'search grants in title_abstract_only for return grants[id]'
 
-    TODO fails with inner escaped quotes 
-        a = 'search grants in title_abstract_only for "Heisenberg limit " and for "\"b\" return c" return grants[id]'
-        re.sub(r'\"(.+?)\"', "", a)
-        # => 'search grants in title_abstract_only for  and for  return c" return grants[id]'
+    DONE succeeds with inner escaped quotes 
+        a = r'search grants in title_abstract_only for "Heisenberg limit " and for "\"b\" return c" return grants[id]'
+        re.sub(r'\"(.+?)\"', "", a.replace(r'\"', ""))
+        # => 'search grants in title_abstract_only for  and for  return grants[id]'
 
     """
-    return re.sub(r'\"(.+?)\"', "", line)
+    return re.sub(r'\"(.+?)\"', "", line.replace(r'\"', ""))
 
 
 def line_count_returns(line):


### PR DESCRIPTION
Dear support,

I believe I found a bug in the dimcli Python package.

The same query resolves with the `query` method and fails with `query_iterative` (see at the bottom to reproduce the issue).

This query searches for "return misfortune" and the word ‘return’ is incorrectly considered as the `return` statement.

I was able to trace the issue in the code:
https://github.com/digital-science/dimcli/blob/36382e2933ece95baa02220f119da31c03f455f9/dimcli/utils/repl_utils.py#L124

It seems the developper identified this drawback, writing ‘TODO fails with inner escaped quotes’...

This commits proposes a solution.

Thanks for considering it.

Guillaume Cabanac


```$ python3
Python 3.10.7 (main, Sep 14 2022, 22:38:23) [Clang 14.0.0 (clang-1400.0.29.102)] on darwin Type "help", "copyright", "credits" or "license" for more information.
>>> import dimcli
>>> dimcli.login()
Searching config file credentials for default 'live' instance.. Dimcli - Dimensions API Client (v0.9.9.1)
Connected to: <https://app.dimensions.ai/api/dsl> - DSL v2.3 Method: dsl.ini file
>>> dsl = dimcli.Dsl()

>>> dsl.query(r'search publications in full_data for "\"return misfortune\"" return publications')
Returned Publications: 20 (total = 48)
Time: 2.75s
WARNINGS [1]
Field current_organization_id of the authors field is deprecated and will be removed in the next major release.
<dimcli.DslDataset object #4788598384. Records: 20/48>

>>> dsl.query_iterative(r'search publications in full_data for "\"return misfortune\"" return publications')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/homebrew/lib/python3.10/site-packages/dimcli/core/api.py", line 264, in query_iterative
    raise Exception("Iterative queries support only 1 return statement")
Exception: Iterative queries support only 1 return statement```